### PR TITLE
[fix] send data instead

### DIFF
--- a/functions/post/getPost.js
+++ b/functions/post/getPost.js
@@ -22,7 +22,7 @@ module.exports = async (req, res) => {
         } = snap.data().d
         const donorsSnap = await db.collection("posts").doc(id).collection("donors").orderBy("createdAt","desc").limit(10).get()
         const donors = []
-        donorsSnap.forEach(donor => donors.push(donor))
+        donorsSnap.forEach(donor => donors.push(donor.data()))
         const createdAt = snap.data().d.createdAt.toDate()
         res.send({
             name,


### PR DESCRIPTION
Send `donor.data()` instead of `donor`.